### PR TITLE
Use `wp_add_inline_script` for publicPath

### DIFF
--- a/lib/wpackio/enqueue/inc/Enqueue.php
+++ b/lib/wpackio/enqueue/inc/Enqueue.php
@@ -145,7 +145,11 @@ class Enqueue {
 	public function printPublicPath() {
 		$publicPath = $this->getUrl( '' );
 		$jsCode = 'window.__wpackIo' . $this->sanitize_path( $this->appName . $this->outputPath ) . '=\'' . esc_js( $publicPath ) . '\';';
-		echo '<script type="text/javascript">/* wpack.io publicPath */' . $jsCode . '</script>';
+
+		// Enqueue an empty script so we can add an inline script that allows for filtering via `wp_inline_script_attributes`
+		\wp_register_script("{$this->appName}/publicPath", '', [], false, true);
+		\wp_enqueue_script("{$this->appName}/publicPath");
+		\wp_add_inline_script("{$this->appName}/publicPath", "/* wpack.io publicPath */ {$jsCode}");
 	}
 
 	/**


### PR DESCRIPTION
Upstream PR: https://github.com/swashata/wpackio-enqueue/pull/18

I know this is a wpackio issue, but I thought I'd drop it here for reference or in the off chance you'd want to incorporate this patch into a new version.

Basically, wpackio is killing CSP when `unsafe-inline` is disabled. The script in question only writes the `window.__wpackIoresponsivePicsdist` variable, which I'm not even sure ResponsivePics uses in any meaningful way. 

Either way, take it or leave it. 😆