### PR TITLE
Use file_exists filter when processing resize requests

### DIFF
--- a/src/class-process.php
+++ b/src/class-process.php
@@ -516,7 +516,15 @@ class RP_Process extends ResponsivePics
 		do_action('responsive_pics_request_processed', $id, $quality, $width, $height, $crop, $ratio, $resize_path, $rest_route);
 
 		// Check if image exists
-		if (!file_exists($resize_path)) {
+		$resized_file_exists = apply_filters('responsive_pics_file_exists', $id, [
+			'path'   => $file_path,
+			'file'   => basename($resize_path),
+			'width'  => $width,
+			'height' => $height,
+			'ratio'  => $ratio,
+	        ]);
+
+		if (!$resized_file_exists) {
 			if (!is_wp_error($wp_editor)) {
 				$wp_editor->set_quality($quality);
 


### PR DESCRIPTION
When using Offload Media, I noticed that certain images were being added to the queue on every page load and being retried over and over again, which caused Action Scheduler tables to balloon quite quickly. 

This is due to the `process_resize_request` action using PHP's `file_exists()` and not the `responsive_pics_file_exists` filter. Basically, the image never makes it into `ResponsivePics()->s3offload->upload_image()`, where the AS3CF item's objects are updated to include the newly resized sizes.

I believe this is the only other place that the filter needs to be implemented, but please correct me if I'm wrong. :)